### PR TITLE
Add dark mode

### DIFF
--- a/adwaita.css
+++ b/adwaita.css
@@ -11,6 +11,15 @@ code, pre {
 body {
   font-family: cantarell;
   padding: 10px;
+  transition: background-color 0.5s,
+              color 0.5s;
+}
+@media (prefers-color-scheme: dark) {
+  dialog {
+    background-color: #3A3A3A;
+    color: white;
+    box-shadow: 0px 0px 20px darkgray;
+  }
 }
 
 /* Dark mode */
@@ -24,13 +33,16 @@ body {
 
 /* LibAdwaita-like buttons */
 
+button {
+    transition: background-color 0.5s,
+                color 0.5s;
+}
 @media (prefers-color-scheme: light) {
  button {
   padding: 15px;
   border: none;
   border-radius: 7.5px;
   background-color: #e6e6e6;
-  transition: background-color 0.1s;
   font-family: cantarell;
  }
 
@@ -49,7 +61,6 @@ body {
   border-radius: 7.5px;
   background-color: #5B5B5B;
   color: white;
-  transition: background-color 0.1s;
   font-family: cantarell;
  }
  button:hover {
@@ -68,7 +79,7 @@ dialog {
   padding: 15px;
   border: 0px;
   border-radius: 10px;
-  box-shadow: 0px 0px 20px gray;
+  box-shadow: 0px 0px 20px black;
 }
 
 /* LibAdwaita-like check boxes */
@@ -154,4 +165,10 @@ kbd {
   background-color: #CCCCCC;
   border-radius: 5px;
   padding: 10px;
+}
+@media (prefers-color-scheme: dark) {
+  kbd {
+    background-color: #5B5B5B;
+    color: white;
+  }
 }

--- a/adwaita.css
+++ b/adwaita.css
@@ -5,6 +5,19 @@
 code, pre {
   font-family: "Red Hat Mono";
 }
+select {
+  padding: 10px;
+  border: 0px;
+  border-radius: 10px;
+  transition: background-color 0.5s,
+              color 0.5s;
+}
+@media (prefers-color-scheme: dark) {
+  select {
+    background-color: #5B5B5B;
+    color: white;
+  }
+}
 
 /* Apply font, padding, other HTML body patches */
 
@@ -80,6 +93,9 @@ dialog {
   border: 0px;
   border-radius: 10px;
   box-shadow: 0px 0px 20px black;
+  transition: background-color 0.5s,
+              box-shadow 0.5s;
+              color 0.5s;
 }
 
 /* LibAdwaita-like check boxes */

--- a/adwaita.css
+++ b/adwaita.css
@@ -13,23 +13,52 @@ body {
   padding: 10px;
 }
 
+/* Dark mode */
+
+@media (prefers-color-scheme: dark) {
+   body {
+     background-color: #3A3A3A;
+     color: white;
+  }
+}
+
 /* LibAdwaita-like buttons */
 
-button {
+@media (prefers-color-scheme: light) {
+ button {
   padding: 15px;
   border: none;
   border-radius: 7.5px;
   background-color: #e6e6e6;
   transition: background-color 0.1s;
   font-family: cantarell;
-}
+ }
 
-button:hover {
+ button:hover {
   background-color: #b0b0b0;
-}
+ }
 
-button:active {
+ button:active {
   background-color: #828282;
+ }
+}
+@media (prefers-color-scheme: dark) {
+ button {
+  padding: 15px;
+  border: none;
+  border-radius: 7.5px;
+  background-color: #5B5B5B;
+  color: white;
+  transition: background-color 0.1s;
+  font-family: cantarell;
+ }
+ button:hover {
+  background-color: #3F3F3F;
+ }
+
+ button:active {
+  background-color: #2D2D2D;
+ }
 }
 
 /* LibAdwaita-like dialogues (only affects <dialog>, not JavaScript

--- a/index.html
+++ b/index.html
@@ -5,7 +5,8 @@
 <body>
 
 <h1>Adwaita.CSS</h1>
-<p>These examples are in English. Adwaita.css should still work for other languages, but has not been tested.</p>
+<p>These examples are in English. Adwaita.CSS should still work for other languages, but has not been tested.</p>
+<p><b>New:</b> Adwaita.CSS now has a dark mode. Turn on your system's dark mode to enable it.</p>
 <h2>Libadwaita Design Test</h2>
 <label class="container">Hi, I'm a checkbox!
   <input type="checkbox">


### PR DESCRIPTION
Adwaita.CSS does not have a dark mode. So, when enabling GNOME's dark mode, you still get a eye-stressing white background on websites that target the Adwaita.CSS stylesheet.

This pull request adds support for dark mode. It's neccesary for Adwaita.CSS to have this, just like standard LibAdwaita.